### PR TITLE
fix docstring of jdn/encode

### DIFF
--- a/jdn.janet
+++ b/jdn.janet
@@ -1,6 +1,7 @@
 
-(defn encode [j]
+(defn encode
   "Encode a janet value to a jdn string."
+  [j]
   (string/format "%j" j))
 
 (defn decode


### PR DESCRIPTION
Before this fix, `(doc jdn/encode)` wouldn't show the expected docstring.